### PR TITLE
GPII-2322 - Convert Docker containers to Alpine Linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM gpii/universal
+FROM alpine:3.6
 
-WORKDIR /etc/ansible/playbooks
+WORKDIR /home/node
 
-COPY ansible/* /etc/ansible/playbooks/
+RUN apk add --no-cache curl git && \
+    git clone --depth=1 https://github.com/GPII/universal.git && \
+    apk del git
 
-RUN ansible-galaxy install -r requirements.yml
+COPY loadPreferences.sh /usr/local/bin
 
-RUN ansible-playbook build.yml --tags "install,configure"
-
-COPY start.sh /usr/local/bin/start.sh
-
-RUN chmod 755 /usr/local/bin/start.sh
-
-ENTRYPOINT ["/usr/local/bin/start.sh"]
+CMD ["/usr/local/bin/loadPreferences.sh"]

--- a/README.md
+++ b/README.md
@@ -1,21 +1,29 @@
-# GPII Preferences Server Data Loader Dockerfile
+# Preferences Data Loader
 
-Builds a [sidecar/sidekick container](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html) for loading the test preferences server data set to a CouchDB instance. Uses the [ansible-preferences-server-data-loader](https://github.com/waharnum/ansible-preferences-server-data-loader) role.
-
+Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html) with the preferences data from the GPII/universal repository baked in and a mechanism for loading them into a CouchDB database.
 
 ## Building
 
-- `docker build -t gpii/preferences-server-data-loader .`
+- `docker build -t gpii/preferences-dataloader .`
 
-## Runtime Environment Variables
+## Environment Variables
 
-- `COUCHDB_HOST_ADDRESS`: host address of the couchdb instance to use. You will typically need to be explicit about this. (default: `localhost:5984`)
-- `CLEAR INDEX`: should the data loading process wipe and recreate the /preferences index? If not set to `true`, this will cause the data load to fail if attempting to load test data to an instance where the test data already exists; you must be explicit in running the container to erase an existing index. (default: `false`)
+- `COUCHDB_URL`: URL of the CouchDB database. (required)
+- `CLEAR_INDEX`: If defined, the database at $COUCHDB_URL will be deleted and recreated. (optional)
+- `PREFERENCES_DIR`: This is useful if you want to mount the preferences data using a Docker volume and point the data loader at it (optional)
 
 ## Running
 
-- running requires a couchdb instance accessible to the container
-- containerized example (including running Preferences Server container)
-  - `docker run -d -p 5984:5984 --name couchdb klaemo/couchdb`
-  - `docker run --rm --link couchdb -e COUCHDB_HOST_ADDRESS=couchdb:5984 -e CLEAR_INDEX=true gpii/preferences-server-data-loader`
-  - `docker run --name prefserver -d -p 8082:8082 --link couchdb -e NODE_ENV=preferencesServer.production -e COUCHDB_HOST_ADDRESS=couchdb:5984 gpii/preferences-server`
+Example using containers:
+
+```
+$ docker run -d -p 5984:5984 --name couchdb couchdb
+$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/preferences -e CLEAR_INDEX=1 gpii/preferences-dataloader
+$ docker run --name prefserver -d -p 8081:8081 --link couchdb -e NODE_ENV=gpii.preferencesServer.config.production -e COUCHDB_HOST_ADDRESS=couchdb gpii/preferences-server
+```
+
+Loading preferences data from a different location (e.g. /mydata):
+
+```
+$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/preferences -e CLEAR_INDEX -e PREFERENCES_DIR=/mydata -v /home/user/mydata:/mydata gpii/preferences-dataloader
+```

--- a/ansible/build-vars.yml
+++ b/ansible/build-vars.yml
@@ -1,3 +1,0 @@
-# See https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml and
-# https://github.com/gpii-ops/ansible-preferences-server-data-loader/blob/master/defaults/main.yml
-# for what can be configured in a build

--- a/ansible/build.yml
+++ b/ansible/build.yml
@@ -1,9 +1,0 @@
----
-- hosts: local
-  connection: local
-  vars_files:
-    - build-vars.yml
-  roles:
-    - facts
-    - nodejs
-    - preferences-server-data-loader

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,0 @@
-# Already present from inclusivedesign/nodejs container
-# - src: https://github.com/idi-ops/ansible-facts
-# - src: https://github.com/idi-ops/ansible-nodejs
-- src: https://github.com/gpii-ops/ansible-preferences-server-data-loader
-  name: preferences-server-data-loader

--- a/ansible/run-vars.yml
+++ b/ansible/run-vars.yml
@@ -1,8 +1,0 @@
-
-# Uses environment variables passed to the container on `docker run`
-# See https://groups.google.com/forum/#!topic/ansible-project/XURTfj64OKA for the use of the default structure below
-# - defaults need to be set here or a blank variable is set from the nonexistent environment variable
----
-preferences_server_data_loader_couchdb_host_address: "{{ lookup('env', 'COUCHDB_HOST_ADDRESS') | default('localhost:5984',true) }}"
-preferences_server_data_loader_cleanup_after: false
-preferences_server_data_loader_clear_index: "{{ lookup('env', 'CLEAR_INDEX') | default(false,true) }}"

--- a/ansible/run.yml
+++ b/ansible/run.yml
@@ -1,9 +1,0 @@
----
-- hosts: local
-  connection: local
-  vars_files:
-    - run-vars.yml
-  roles:
-    - facts
-    - nodejs
-    - preferences-server-data-loader

--- a/loadPreferences.sh
+++ b/loadPreferences.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+PREFS_DIR=${PREFERENCES_DIR:-/home/node/universal/testData/preferences}
+
+log() {
+  echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
+}
+
+if [ -z "$COUCHDB_URL" ]; then
+  echo "COUCHDB_URL environment variable must be defined"
+  exit 1
+fi
+
+log "Starting"
+
+if [ ! -z "$CLEAR_INDEX" ]; then
+  log "Deleting database at $COUCHDB_URL"
+  if ! curl -fsS -X DELETE "$COUCHDB_URL"; then
+    log "Error deleting database"
+    exit 1
+  fi
+fi
+
+log "Creating database at $COUCHDB_URL"
+if ! curl -fsS -X PUT "$COUCHDB_URL"; then
+  log "Error creating database"
+  exit 1
+fi
+
+# Submit preferences
+for file in $PREFS_DIR/*.json; do
+  FILENAME=$(basename "$file" .json)
+  DATA="{ \"_id\":\"$FILENAME\", \"value\":$(cat "$file") }"
+
+  log "Submitting $FILENAME.json"
+  if ! curl -fsS -q -H 'Content-Type: application/json' -X POST "$COUCHDB_URL" -d "$DATA"; then
+    log "Error submitting $FILENAME. Terminating."
+    exit 1
+  fi
+
+done

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,0 @@
-#!/bin/sh -e
-
-ansible-playbook run.yml --tags "deploy,test"


### PR DESCRIPTION
Continuing the work to convert from CentOS+Ansible to Alpine where it makes sense.

The image built with this PR is 10MB (54 lines) versus 727MB (166 lines) for the CentOS+Ansible version.

If this is accepted, I can take care of fixing the CI configuration (because I changed some variable names).

I'm also proposing we rename the container from "gpii/preferences-server-data-loader to "gpii/preferences-dataloader" to keep it short.

/cc @amatas @mrtyler 