### PR TITLE
GPII-2630: To accommodate the implemetation of the new GPII data model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apk add --no-cache curl git && \
     rm package-lock.json && \
     npm install json5 && \
     npm install fs && \
-    rm -rf build && \
-    mkdir -p build/dbData && \
+    npm install rimraf && \
+    npm install mkdirp && \
     node scripts/convertPrefs.js testData/preferences/ build/dbData/ && \
     apk del git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /home/node
 
 RUN apk add --no-cache curl git && \
     git clone --depth=1 -b GPII-2630 https://github.com/cindyli/universal.git && \
+    cd universal && \
     npm install && \
     apk del git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.11.1
+FROM node:8-alpine
 
 WORKDIR /home/node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 WORKDIR /home/node
 
 RUN apk add --no-cache curl git && \
-    git clone --depth=1 --b GPII-2630 https://github.com/cindyli/universal.git && \
+    git clone --depth=1 -b GPII-2630 https://github.com/cindyli/universal.git && \
     apk del git
 
 COPY loadPreferences.sh /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 WORKDIR /home/node
 
 RUN apk add --no-cache curl git && \
-    git clone --depth=1 https://github.com/GPII/universal.git && \
+    git clone --depth=1 --b GPII-2630 https://github.com/cindyli/universal.git && \
     apk del git
 
 COPY loadPreferences.sh /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ RUN apk add --no-cache curl git && \
     git clone --depth=1 -b GPII-2630 https://github.com/cindyli/universal.git && \
     apk del git
 
-COPY loadPreferences.sh /usr/local/bin
+COPY loadData.sh /usr/local/bin
 
-CMD ["/usr/local/bin/loadPreferences.sh"]
+CMD ["/usr/local/bin/loadData.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apk add --no-cache curl git && \
     cd universal && \
     rm package-lock.json && \
     npm install json5 && \
+    npm install fs && \
+    rm -rf build && \
+    mkdir -p build/dbData && \
+    node scripts/convertPrefs.js testData/preferences/ build/dbData/ && \
     apk del git
 
 COPY loadData.sh /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM alpine:3.6
+FROM node:9.11.1
 
 WORKDIR /home/node
 
 RUN apk add --no-cache curl git && \
     git clone --depth=1 -b GPII-2630 https://github.com/cindyli/universal.git && \
+    node /home/node/universal/scripts/convertPrefs.js /home/node/universal/testData/preferences/ /home/node/universal/build/dbData/ && \
     apk del git
 
 COPY loadData.sh /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM node:8-alpine
 WORKDIR /home/node
 
 RUN apk add --no-cache curl git && \
-    git clone --depth=1 -b GPII-2630 https://github.com/cindyli/universal.git && \
+    git clone -b GPII-2630 https://github.com/cindyli/universal.git && \
     cd universal && \
-    npm install && \
+    rm package-lock.json && \
+    npm install json5 && \
     apk del git
 
 COPY loadData.sh /usr/local/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/node
 
 RUN apk add --no-cache curl git && \
     git clone --depth=1 -b GPII-2630 https://github.com/cindyli/universal.git && \
-    node /home/node/universal/scripts/convertPrefs.js /home/node/universal/testData/preferences/ /home/node/universal/build/dbData/ && \
+    npm install && \
     apk del git
 
 COPY loadData.sh /usr/local/bin

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ $ docker run -d -p 8081:8081 --name preferences --link couchdb -e NODE_ENV=gpii.
 
 ```
 
-Loading couchdb data from a different location (e.g. /mydata):
+Loading couchdb data from a different location (e.g. /home/vagrant/sync/universal/testData/dbData for static data directory and /home/vagrant/sync/universal/build/dbData for build data directory):
 
 ```
-$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 -e STATIC_DATA_DIR=/static_data -v /home/user/static_data:/mydata -e BUILD_DATA_DIR=/build_data -v /home/user/build_data:/mydata gpii/gpii-dataloader
+$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/gpii-dataloader
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-s
 
 ## Building
 
-- `docker build -t gpii/preferences-dataloader .`
+- `docker build -t gpii/gpii-dataloader .`
 
 ## Environment Variables
 
@@ -18,12 +18,12 @@ Example using containers:
 
 ```
 $ docker run -d -p 5984:5984 --name couchdb couchdb
-$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/preferences-dataloader
+$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/gpii-dataloader
 $ docker run --name flowmanager -d -p 8081:8081 --link couchdb -e NODE_ENV=gpii.config.cloudBased.production -e COUCHDB_HOST_ADDRESS=couchdb gpii/flow-manager
 ```
 
 Loading couchdb data from a different location (e.g. /mydata):
 
 ```
-$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX -e DBDATA_DIR=/mydata -v /home/user/mydata:/mydata gpii/preferences-dataloader
+$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX -e DBDATA_DIR=/mydata -v /home/user/mydata:/mydata gpii/gpii-dataloader
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Preferences Data Loader
+# CouchDB Data Loader
 
-Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html) with the preferences data from the GPII/universal repository baked in and a mechanism for loading them into a CouchDB database.
+Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html) with the CouchDB data from the GPII/universal repository baked in and a mechanism for loading them into a CouchDB database.
 
 ## Building
 
@@ -10,7 +10,7 @@ Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-s
 
 - `COUCHDB_URL`: URL of the CouchDB database. (required)
 - `CLEAR_INDEX`: If defined, the database at $COUCHDB_URL will be deleted and recreated. (optional)
-- `PREFERENCES_DIR`: This is useful if you want to mount the preferences data using a Docker volume and point the data loader at it (optional)
+- `DBDATA_DIR`: This is useful if you want to mount the database data using a Docker volume and point the data loader at it (optional)
 
 ## Running
 
@@ -18,12 +18,12 @@ Example using containers:
 
 ```
 $ docker run -d -p 5984:5984 --name couchdb couchdb
-$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/preferences -e CLEAR_INDEX=1 gpii/preferences-dataloader
-$ docker run --name prefserver -d -p 8081:8081 --link couchdb -e NODE_ENV=gpii.preferencesServer.config.production -e COUCHDB_HOST_ADDRESS=couchdb gpii/preferences-server
+$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/preferences-dataloader
+$ docker run --name flowmanager -d -p 8081:8081 --link couchdb -e NODE_ENV=gpii.config.cloudBased.production -e COUCHDB_HOST_ADDRESS=couchdb gpii/flow-manager
 ```
 
-Loading preferences data from a different location (e.g. /mydata):
+Loading couchdb data from a different location (e.g. /mydata):
 
 ```
-$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/preferences -e CLEAR_INDEX -e PREFERENCES_DIR=/mydata -v /home/user/mydata:/mydata gpii/preferences-dataloader
+$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX -e DBDATA_DIR=/mydata -v /home/user/mydata:/mydata gpii/preferences-dataloader
 ```

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Example using containers:
 ```
 $ docker run -d -p 5984:5984 --name couchdb couchdb
 $ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/gpii-dataloader
-$ docker run --name flowmanager -d -p 8081:8081 --link couchdb -e NODE_ENV=gpii.config.cloudBased.production -e COUCHDB_HOST_ADDRESS=couchdb gpii/flow-manager
+$ docker run -d -p 8081:8081 --name preferences --link couchdb -e NODE_ENV=gpii.config.preferencesServer.standalone.production  -e PREFERENCESSERVER_LISTEN_PORT=8081 -e DATASOURCE_HOSTNAME=http://couchdb -e DATASOURCE_PORT=5984 vagrant-universal
+
 ```
 
 Loading couchdb data from a different location (e.g. /mydata):
 
 ```
-$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX -e DBDATA_DIR=/mydata -v /home/user/mydata:/mydata gpii/gpii-dataloader
+$ docker run --rm -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 -e STATIC_DATA_DIR=/static_data -v /home/user/static_data:/mydata -e BUILD_DATA_DIR=/build_data -v /home/user/build_data:/mydata gpii/gpii-dataloader
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-s
 
 - `COUCHDB_URL`: URL of the CouchDB database. (required)
 - `CLEAR_INDEX`: If defined, the database at $COUCHDB_URL will be deleted and recreated. (optional)
-- `DBDATA_DIR`: This is useful if you want to mount the database data using a Docker volume and point the data loader at it (optional)
+- `STATIC_DATA_DIR`: The directory where the static data to be loaded into CouchDB resides. (optional)
+- `BUILD_DATA_DIR`: The directory where the data built from a npm step resides. (optional)
+
+The use of environment variables for data directories is useful if you want to mount the database data using a Docker volume and point the data loader at it.
+
+Note that since [the docker doesn't support the environment variable type of array](https://github.com/moby/moby/issues/20169), two separate environment variables are used for inputting data directories instead of one array that holds these directories.
 
 ## Running
 

--- a/loadData.sh
+++ b/loadData.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-DATA_DIR=${DBDATA_DIR:-/home/node/universal/testData/dbData}
+STATIC_DATA_DIR=${STATIC_DATA_DIR:-/home/node/universal/testData/dbData}
+BUILD_DATA_DIR=${BUILD_DATA_DIR:-/home/node/universal/build/dbData}
+
+DATA_DIRS=($STATIC_DATA_DIR $BUILD_DATA_DIR)
 
 log() {
   echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
@@ -26,16 +29,20 @@ if ! curl -fsS -X PUT "$COUCHDB_URL"; then
 fi
 
 # Submit data
-for file in $DATA_DIR/*.json; do
-  log "Submitting $file"
+for data_dir in ${DATA_DIRS[@]}; do
+    log "Loading data from $data_dir"
+    for file in $data_dir/*.json; do
+      log "Submitting $file"
 
-  curl -H 'Content-Type: application/json' -X POST "$COUCHDB_URL/_bulk_docs" -d @- <<CURL_DATA
+      curl -H 'Content-Type: application/json' -X POST "$COUCHDB_URL/_bulk_docs" -d @- <<CURL_DATA
 {"docs": $(cat $file)}
 CURL_DATA
 
-  if [ $? -ne 0 ]; then
-    log "Error submitting $file. Terminating."
-    exit 1
-  fi
+      if [ $? -ne 0 ]; then
+        log "Error submitting $file. Terminating."
+        exit 1
+      fi
 
+      log "Finished loading data from $data_dir"
+    done
 done

--- a/loadData.sh
+++ b/loadData.sh
@@ -26,7 +26,7 @@ if ! curl -fsS -X PUT "$COUCHDB_URL"; then
   exit 1
 fi
 
-# Submit preferences
+# Submit data
 for file in $DATA_DIR/*.json; do
   log "Submitting $file"
 

--- a/loadData.sh
+++ b/loadData.sh
@@ -26,7 +26,7 @@ if ! curl -fsS -X PUT "$COUCHDB_URL"; then
 fi
 
 # Submit data
-for file in $DATA_DIR/*.json5; do
+for file in $DATA_DIR/*.json; do
   log "Submitting $file"
 
   curl -H 'Content-Type: application/json' -X POST "$COUCHDB_URL/_bulk_docs" -d @- <<CURL_DATA

--- a/loadData.sh
+++ b/loadData.sh
@@ -22,8 +22,7 @@ fi
 
 log "Creating database at $COUCHDB_URL"
 if ! curl -fsS -X PUT "$COUCHDB_URL"; then
-  log "Error creating database"
-  exit 1
+  log "Database already exists at $COUCHDB_URL"
 fi
 
 # Submit data

--- a/loadData.sh
+++ b/loadData.sh
@@ -27,7 +27,7 @@ if ! curl -fsS -X PUT "$COUCHDB_URL"; then
 fi
 
 # Submit data
-for file in $DATA_DIR/*.json; do
+for file in $DATA_DIR/*.json5; do
   log "Submitting $file"
 
   curl -H 'Content-Type: application/json' -X POST "$COUCHDB_URL/_bulk_docs" -d @- <<CURL_DATA

--- a/loadPreferences.sh
+++ b/loadPreferences.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PREFS_DIR=${PREFERENCES_DIR:-/home/node/universal/testData/preferences}
+DATA_DIR=${DBDATA_DIR:-/home/node/universal/testData/dbData}
 
 log() {
   echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
@@ -27,13 +27,12 @@ if ! curl -fsS -X PUT "$COUCHDB_URL"; then
 fi
 
 # Submit preferences
-for file in $PREFS_DIR/*.json; do
-  FILENAME=$(basename "$file" .json)
-  DATA="{ \"_id\":\"$FILENAME\", \"value\":$(cat "$file") }"
+for file in $DATA_DIR/*.json; do
+  DATA="{ \"docs\":$(cat "$file") }"
 
-  log "Submitting $FILENAME.json"
-  if ! curl -fsS -q -H 'Content-Type: application/json' -X POST "$COUCHDB_URL" -d "$DATA"; then
-    log "Error submitting $FILENAME. Terminating."
+  log "Submitting $file"
+  if ! curl -H 'Content-Type: application/json' -X POST "$COUCHDB_URL/_bulk_docs" -d "$DATA"; then
+    log "Error submitting $file. Terminating."
     exit 1
   fi
 

--- a/loadPreferences.sh
+++ b/loadPreferences.sh
@@ -28,10 +28,13 @@ fi
 
 # Submit preferences
 for file in $DATA_DIR/*.json; do
-  DATA="{ \"docs\":$(cat "$file") }"
-
   log "Submitting $file"
-  if ! curl -H 'Content-Type: application/json' -X POST "$COUCHDB_URL/_bulk_docs" -d "$DATA"; then
+
+  curl -H 'Content-Type: application/json' -X POST "$COUCHDB_URL/_bulk_docs" -d @- <<CURL_DATA
+{"docs": $(cat $file)}
+CURL_DATA
+
+  if [ $? -ne 0 ]; then
     log "Error submitting $file. Terminating."
     exit 1
   fi


### PR DESCRIPTION
With the implementation of the new data model, this data loader is no longer limited to load preferences data. It now loads all GPII data into CouchDB, including the preferences and auth data.

These tasks should be taken care before merging this pull request:

1. [This line in Dockerfile](https://github.com/cindyli/docker-preferences-dataloader/blob/GPII-2630/Dockerfile#L6) should "git clone" from the universal master instead of cindyli/GPII-2630;
2. Consider to rename the name of this repository to "docker-gpii-dataloader".

This pull request should be merged once https://github.com/GPII/universal/pull/591 is merged into the universal master branch.