### PR TITLE
Fix the build because package-lock.json can not be present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /home/node
 RUN apk add --no-cache curl git && \
     git clone https://github.com/GPII/universal.git && \
     cd universal && \
-    rm package-lock.json && \
+    rm -f package-lock.json && \
     npm install json5 && \
     npm install fs && \
     npm install rimraf && \


### PR DESCRIPTION
Since the [deletion of package-lock.json file](https://github.com/GPII/universal/commit/7218a34683ddf2a41de05af769772f9dc5b36dce) the build fails. This PR fixes the error:

```
Executing busybox-1.26.2-r9.trigger
Executing ca-certificates-20161130-r2.trigger
OK: 27 MiB in 20 packages
[91mCloning into 'universal'...
[0m[91mrm: can't remove 'package-lock.json': No such file or directory
[0mThe command '/bin/sh -c apk add --no-cache curl git &&     git clone https://github.com/GPII/universal.git &&     cd universal &&     rm package-lock.json &&     npm install json5 &&     npm install fs &&     npm install rimraf &&     npm install mkdirp &&     node scripts/convertPrefs.js testData/preferences/ build/dbData/ &&     apk del git' returned a non-zero code: 1
Build step 'Execute shell' marked build as failure
Finished: FAILURE

```