### PR TITLE
GPII-3250: Pre-warm the data loaded by dataloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:8-alpine
 
 WORKDIR /home/node
 
-RUN apk add --no-cache curl git && \
+RUN apk add --no-cache curl git jq && \
     git clone https://github.com/GPII/universal.git && \
     cd universal && \
     rm -f package-lock.json && \

--- a/loadData.sh
+++ b/loadData.sh
@@ -7,6 +7,12 @@ log() {
   echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
 }
 
+warm(){
+  VIEW=$1
+
+  curl -fsS $COUCHDB_URL/_design/views/_view/$VIEW >/dev/null
+}
+
 loadData() {
   log "Loading data from $1"
 
@@ -47,3 +53,10 @@ fi
 # Submit data
 loadData $STATIC_DATA_DIR
 loadData $BUILD_DATA_DIR
+
+# Warm Data
+log "Warming indices..."
+warm findPrefsSafeByGpiiKey
+warm findClientByOauth2ClientId
+warm findAuthorizationByAccessToken
+log "Finished warming indices..."

--- a/loadData.sh
+++ b/loadData.sh
@@ -7,10 +7,14 @@ log() {
   echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
 }
 
-warm(){
-  VIEW=$1
+warm_indices(){
+  log "Warming indices..."
 
-  curl -fsS $COUCHDB_URL/_design/views/_view/$VIEW >/dev/null
+  for view in $(curl -s $COUCHDB_URL/_design/views/ | jq -r '.views | keys[]'); do
+    curl -fsS $COUCHDB_URL/_design/views/_view/$view >/dev/null
+  done
+
+  log "Finished warming indices..."
 }
 
 loadData() {
@@ -55,8 +59,4 @@ loadData $STATIC_DATA_DIR
 loadData $BUILD_DATA_DIR
 
 # Warm Data
-log "Warming indices..."
-warm findPrefsSafeByGpiiKey
-warm findClientByOauth2ClientId
-warm findAuthorizationByAccessToken
-log "Finished warming indices..."
+warm_indices


### PR DESCRIPTION
Previously, the first query to couchdb would take a hit on total time. This in turn will skew the various load/performance tests that we're running at the infrastructure level. 